### PR TITLE
feat: Add GRPC health checking functionality

### DIFF
--- a/pkg/config/dynamic/http_config.go
+++ b/pkg/config/dynamic/http_config.go
@@ -185,6 +185,7 @@ type HealthCheck struct {
 	Hostname        string            `json:"hostname,omitempty" toml:"hostname,omitempty" yaml:"hostname,omitempty"`
 	FollowRedirects *bool             `json:"followRedirects" toml:"followRedirects" yaml:"followRedirects"`
 	Headers         map[string]string `json:"headers,omitempty" toml:"headers,omitempty" yaml:"headers,omitempty"`
+	Service         string            `json:"service,omitempty" toml:"service,omitempty" yaml:"service,omitempty"`
 }
 
 // SetDefaults Default values for a HealthCheck.

--- a/pkg/server/service/service.go
+++ b/pkg/server/service/service.go
@@ -283,6 +283,7 @@ func buildHealthCheckOptions(ctx context.Context, lb healthcheck.Balancer, backe
 		Hostname:        hc.Hostname,
 		Headers:         hc.Headers,
 		FollowRedirects: followRedirects,
+		Service:         hc.Service,
 	}
 }
 


### PR DESCRIPTION
Activate by setting `service` on healthcheck to the name of the gRPC
service or by having the scheme be `h2c` and the path `/grpc.health.v1.Health/Check`.

eg. in Redis

```redis
set traefik/http/services/best-grpc/loadbalancer/healthcheck/service badgers
```

Or

```redis
set traefik/http/services/best-grpc/loadbalancer/servers/127.0.0.1/url h2c://localhost:12345/
set traefik/http/services/best-grpc/loadbalancer/healthcheck/path /grpc.health.v1.Health/Check
```

<!--
PLEASE READ THIS MESSAGE.

Documentation fixes or enhancements:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Bug fixes:
- for Traefik v1: use branch v1.7
- for Traefik v2: use branch v2.2

Enhancements:
- for Traefik v1: we only accept bug fixes
- for Traefik v2: use branch master

HOW TO WRITE A GOOD PULL REQUEST? https://docs.traefik.io/contributing/submitting-pull-requests/

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->


### Motivation

<!-- What inspired you to submit this pull request? -->


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

<!-- Anything else we should know when reviewing? -->
